### PR TITLE
Fix job scheduled without checking precedence constraints

### DIFF
--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -772,6 +772,10 @@ namespace NP {
 					// stop looking once we've left the window of interest
 					if (j.earliest_arrival() > t_wc)
 						break;
+
+					// Job could be not ready due to precedence constraints
+					if (!ready(s, j)) continue;
+
 					// Since this job is released in the future, it better
 					// be incomplete...
 					assert(unfinished(s, j));

--- a/include/global/space.hpp
+++ b/include/global/space.hpp
@@ -774,7 +774,8 @@ namespace NP {
 						break;
 
 					// Job could be not ready due to precedence constraints
-					if (!ready(s, j)) continue;
+					if (!ready(s, j))
+						continue;
 
 					// Since this job is released in the future, it better
 					// be incomplete...

--- a/src/tests/global_prec.cpp
+++ b/src/tests/global_prec.cpp
@@ -49,6 +49,19 @@ const std::string ts2_edges =
 "       1,       13,        1,       15\n"
 "       1,       14,        1,       15\n";
 
+const std::string ts3_jobs =
+"Task ID, Job ID, Arrival min, Arrival max, Cost min, Cost max, Deadline, Priority\n"
+"      0,      0,          10,          10,       80,       80,      110,        2\n"
+"      1,      0,         200,         200,       20,       20,     8000,        4\n"
+"      2,      0,         200,         200,       20,       20,     8000,        5\n"
+"      3,      0,         200,         200,       40,       40,     8000,        3\n"
+"      0,      1,         210,         210,       80,       80,     310,         2\n";
+
+const std::string ts3_edges =
+"From TID, From JID,   To TID,   To JID\n"
+"       1,        0,        2,        0\n"
+"       2,        0,        3,        0\n";
+
 TEST_CASE("[global-prec] taskset-1") {
 	auto dag_in = std::istringstream(ts1_edges);
 	auto dag = NP::parse_dag_file(dag_in);
@@ -130,4 +143,21 @@ TEST_CASE("[global-prec] taskset-2") {
 		if (j.least_cost() != 0)
 			CHECK(nspace3.get_finish_times(j).from() != 0);
 	}
+}
+
+TEST_CASE("[global-prec] taskset-3") {
+	auto dag_in = std::istringstream(ts3_edges);
+	auto dag = NP::parse_dag_file(dag_in);
+
+	auto in = std::istringstream(ts3_jobs);
+	auto jobs = NP::parse_file<dtime_t>(in);
+
+	NP::Scheduling_problem<dtime_t> prob{jobs, dag};
+	NP::Analysis_options opts;
+
+	prob.num_processors = 1;
+	opts.be_naive = false;
+	auto space = NP::Global::State_space<dtime_t>::explore(prob, opts);
+
+	CHECK(space.is_schedulable());
 }


### PR DESCRIPTION
Good afternoon,

As discussed by e-mail, there was a condition where jobs with precedence constraints could be scheduled even if their precedence constraints were not finished.

This PR fixes that issue. An example that illustrates this issue can be found 
here: [schedule_results.tar.gz](https://github.com/brandenburg/np-schedulability-analysis/files/4461571/schedule_results.tar.gz). There are two directories:

- **before**: Results before applying this change
- **after**: Results after applying this change

The task set has a lot of jobs but the important part is that task 4 depends on task 3 which depends on task 2. The example does not have jitter and thus it should be deterministic so only one state should follow the previous one. In the "before" results we can see that state S17 has two successors one of them consists in scheduling T4J1 which shouldn't be possible as the other option schedules T2J1 (and we have the T4 -> T3 -> T2 dependency). 

After applying this fix, this does not happen anymore and we obtain the results in the "after" directory.