### PR TITLE
Fix t_L calculation for work-conserving policies on uniprocessor

### DIFF
--- a/src/tests/state_space.cpp
+++ b/src/tests/state_space.cpp
@@ -376,3 +376,24 @@ TEST_CASE("[NP state space] explore across bucket boundaries") {
 	CHECK(space.number_of_edges() == 3);
 }
 
+TEST_CASE("[NP state space] start times satisfy work-conserving property")
+{
+    Job<dtime_t> j0{0, I( 0,  0), I(2, 2), 10, 2, 0};
+    Job<dtime_t> j1{1, I(0, 8), I(2, 2), 10, 1, 1};
+
+    Uniproc::State_space<dtime_t>::Workload jobs{j0, j1};
+
+    SUBCASE("naive exploration") {
+        auto space = Uniproc::State_space<dtime_t>::explore_naively(jobs);
+        CHECK(space.is_schedulable());
+        CHECK(space.get_finish_times(j0) == I(2, 4));
+        CHECK(space.get_finish_times(j1) == I(2, 10));
+    }
+
+    SUBCASE("exploration with state-merging") {
+        auto space = Uniproc::State_space<dtime_t>::explore(jobs);
+        CHECK(space.is_schedulable());
+        CHECK(space.get_finish_times(j0) == I(2, 4));
+        CHECK(space.get_finish_times(j1) == I(2, 10));
+    }
+}


### PR DESCRIPTION
In this PR, `t_L` (as defined below Eq. 3 in RTSS17) is corrected to be `max{l_i, min{r_x^max | J_x \in J\J^P, J_x is an eligible job at max{r_x^max, l_i} according to Definition 4 in RTSS17}}`, instead of `max{l_i,r_j^max}`. This solves the problem where the processor is sometimes incorrectly left idle when it should not be according to the work-conserving policy.

In the following example, the original code incorrectly reports the latest start time of T1J1 after S1 to be 8 (as can be seen in the left graph). This should not be possible using a work-conserving as T0J0 is certainly released at time 0. The right graph shows the SAG generated by the code in this PR, which correctly determines the LST of T1J1 after S1 to be 0. 

Example:
```
Task ID, Job ID, Arrival min, Arrival max, Cost min, Cost max, Deadline, Priority
0,0,0,0,2,2,10,2
1,1,0,8,2,2,10,1
```

![instance1-bug](https://user-images.githubusercontent.com/23633658/131128007-329e3bfc-03af-4ff3-b1fc-6ba56e724856.png)![instance1-fixed](https://user-images.githubusercontent.com/23633658/131128073-98c388b0-9b73-486f-b698-ef880d3f7593.png)
