### PR TITLE
Fix bug omitting some eligible successors in P-RM and CW-EDF

### DIFF
--- a/include/uni/space.hpp
+++ b/include/uni/space.hpp
@@ -326,14 +326,14 @@ namespace NP {
 					// If the job is not IIP-eligible when it is certainly
 					// released, then there exists a schedule where it doesn't
 					// count, so skip it.
-					if (!iip_eligible(s, j, j.latest_arrival()))
+					if (!iip_eligible(s, j, std::max(j.latest_arrival(), s.latest_finish_time())))
 						continue;
 
 					// It must be priority-eligible when released, too.
 					// Relevant only if we have an IIP, otherwise the job is
 					// trivially priority-eligible.
 					if (iip.can_block &&
-					    !priority_eligible(s, j, j.latest_arrival()))
+					    !priority_eligible(s, j, std::max(j.latest_arrival(), s.latest_finish_time())))
 						continue;
 
 					// great, this job fits the bill
@@ -496,9 +496,6 @@ namespace NP {
 				// job is trivially potentially next, so check the other case.
 
 				if (t_latest < j.earliest_arrival()) {
-					if (exists_certainly_pending_job(s))
-						return false;
-
 					Time r = next_certain_job_release(s);
 					// if something else is certainly released before j and IIP-
 					// eligible at the time of certain release, then j can't
@@ -795,10 +792,10 @@ namespace NP {
 					// Identify relevant interval for next job
 					// relevant job buckets
 					auto ts_min = s.earliest_finish_time();
-					auto latest_idle = next_certain_job_release(s);
+					auto rel_min = s.earliest_job_release();
+					auto t_l = std::max(next_eligible_job_ready(s), s.latest_finish_time());
 
-					Interval<Time> next_range{ts_min,
-					    std::max(latest_idle, s.latest_finish_time())};
+					Interval<Time> next_range{std::min(ts_min, rel_min), t_l};
 
 					DM("ts_min = " << ts_min << std::endl <<
 					   "latest_idle = " << latest_idle << std::endl <<
@@ -898,10 +895,9 @@ namespace NP {
 					// relevant job buckets
 					auto ts_min = s.earliest_finish_time();
 					auto rel_min = s.earliest_job_release();
-					auto latest_idle = next_certain_job_release(s);
+					auto t_l = std::max(next_eligible_job_ready(s), s.latest_finish_time());
 
-					Interval<Time> next_range{ts_min,
-					    std::max(latest_idle, s.latest_finish_time())};
+					Interval<Time> next_range{std::min(ts_min, rel_min), t_l};
 
 					DM("ts_min = " << ts_min << std::endl <<
 					   "rel_min = " << rel_min << std::endl <<

--- a/src/tests/iip.cpp
+++ b/src/tests/iip.cpp
@@ -101,6 +101,44 @@ TEST_CASE("[IIP] P-RM negative example (Figure 2)")
 
 }
 
+TEST_CASE("[IIP] P-RM example extra branch")
+{
+    Uniproc::State_space<dtime_t>::Workload jobs{
+        Job<dtime_t>{0, I( 1,  1), I(1, 1), 3, 0, 0},
+        Job<dtime_t>{1, I(4, 4), I(1, 1), 6, 0, 0},
+        Job<dtime_t>{2, I( 0,  0), I(1, 2), 3, 1, 1},
+        Job<dtime_t>{3, I(2, 2), I(3, 3), 6, 2, 2},
+        };
+
+    SUBCASE("RM, naive exploration") {
+        auto space = Uniproc::State_space<dtime_t>::explore_naively(jobs);
+        CHECK(!space.is_schedulable());
+        CHECK(space.number_of_states() == 5);
+        CHECK(space.number_of_edges() == 4);
+    }
+
+    SUBCASE("RM, exploration with state-merging") {
+        auto space = Uniproc::State_space<dtime_t>::explore(jobs);
+        CHECK(!space.is_schedulable());
+        CHECK(space.number_of_states() == 5);
+        CHECK(space.number_of_edges() == 4);
+    }
+
+    SUBCASE("P-RM, naive exploration") {
+        auto space = Uniproc::State_space<dtime_t, Uniproc::Precatious_RM_IIP<dtime_t>>::explore_naively(jobs);
+        CHECK(!space.is_schedulable());
+        CHECK(space.number_of_states() == 7);
+        CHECK(space.number_of_edges() == 6);
+    }
+
+    SUBCASE("P-RM, exploration with state-merging") {
+        auto space = Uniproc::State_space<dtime_t, Uniproc::Precatious_RM_IIP<dtime_t>>::explore(jobs);
+        CHECK(!space.is_schedulable());
+        CHECK(space.number_of_states() == 7);
+        CHECK(space.number_of_edges() == 6);
+    }
+
+}
 
 // The example in Fig 2b of Nasri & Fohler (ECRTS 2016):
 //    "Non-Work-Conserving Non-Preemptive Scheduling:

--- a/src/tests/iip.cpp
+++ b/src/tests/iip.cpp
@@ -193,7 +193,6 @@ TEST_CASE("[IIP] CW-EDF extra example")
 
 }
 
-
 TEST_CASE("[IIP] P-RM idle time")
 {
 	Uniproc::State_space<dtime_t>::Workload jobs{

--- a/src/tests/state_space.cpp
+++ b/src/tests/state_space.cpp
@@ -376,3 +376,24 @@ TEST_CASE("[NP state space] explore across bucket boundaries") {
 	CHECK(space.number_of_edges() == 3);
 }
 
+TEST_CASE("[NP state space] start times satisfy work-conserving property")
+{
+    Job<dtime_t> j0{0, I( 0,  0), I(2, 2), 10, 2, 0};
+    Job<dtime_t> j1{1, I(0, 8), I(2, 2), 10, 1, 1};
+
+    Uniproc::State_space<dtime_t>::Workload jobs{j0, j1};
+
+    SUBCASE("naive exploration") {
+        auto space = Uniproc::State_space<dtime_t>::explore_naively(jobs);
+        CHECK(space.is_schedulable());
+        CHECK(space.get_finish_times(j0) == I(2, 4));
+        CHECK(space.get_finish_times(j1) == I(2, 10));
+    }
+
+    SUBCASE("exploration with state-merging") {
+        auto space = Uniproc::State_space<dtime_t>::explore(jobs);
+        CHECK(space.is_schedulable());
+        CHECK(space.get_finish_times(j0) == I(2, 4));
+        CHECK(space.get_finish_times(j1) == I(2, 10));
+    }
+}


### PR DESCRIPTION
Currently, the analysis fails to include some branches that should have been added according to the P-RM and CW-EDF policies. When running the below example with P-RM, the current code does not create a branch with T0J1 as a successor to S3 (as in the left graph), even though there should be. This PR fixes this issue as follows:

- The lower bound of `next_range` now includes the earliest job release after `s`, as only considering the EFT of `s` causes some successors to be missed. 
- The upper bound of `next_range` includes the new definition of `t_L` (#3), to include jobs that can be next after an idle time insertion, which are currently not all found. 
- `potentially_next` has been updated to reflect Definition 4 of RTSS17 more closely by removing the check that prematurely rejects jobs, and changing `next_certain_job_release` to check IIP- and priority-eligibility at max(r_x^max, l_i) as in Definition 4. 

and now creates the graph on the right, where a branch for T0J1 is included. Since this PR depends on #3, that one should be merged first. 

Example:
```
Task ID, Job ID, Arrival min, Arrival max, Cost min, Cost max, Deadline, Priority
0,0,8,8,2,2,10,2
1,1,0,8,2,2,10,1
```

![instance](https://user-images.githubusercontent.com/23633658/131129965-32d7a53d-ecd2-40f0-92b2-e2c45be13b02.png)![prm-fixed](https://user-images.githubusercontent.com/23633658/131129976-6e1c6355-e4e8-4ba3-b9b2-e391328f833d.png)


